### PR TITLE
Merge bug/sanitize-next-primary-weapon-id

### DIFF
--- a/src/entity.h
+++ b/src/entity.h
@@ -47,6 +47,7 @@ struct entity : persistent_entity
 
 enum { GUN_KNIFE = 0, GUN_PISTOL, GUN_CARBINE, GUN_SHOTGUN, GUN_SUBGUN, GUN_SNIPER, GUN_ASSAULT, GUN_CPISTOL, GUN_GRENADE, GUN_AKIMBO, NUMGUNS };
 #define reloadable_gun(g) (g != GUN_KNIFE && g != GUN_GRENADE)
+#define valid_weapon(g) (g >= GUN_KNIFE && g < NUMGUNS && g != GUN_CPISTOL)
 
 #define SGRAYS 21
 #define SGDMGTOTAL 90

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2810,7 +2810,8 @@ void process(ENetPacket *packet, int sender, int chan)
             getstring(text, p);
             filterlang(cl->lang, text);
             int wantrole = getint(p);
-            cl->state.nextprimary = getint(p);
+            int nextprimary = getint(p);
+            cl->state.nextprimary = valid_weapon(nextprimary) ? nextprimary : GUN_ASSAULT;
             loopi(2) cl->skin[i] = getint(p);
             Lua::callHandler( LUA_ON_PLAYER_PRECONNECT, "i", sender );
             int bantype = getbantype(sender);
@@ -3147,7 +3148,7 @@ void process(ENetPacket *packet, int sender, int chan)
             case SV_PRIMARYWEAP:
             {
                 int nextprimary = getint(p);
-                if(nextprimary<0 && nextprimary>=NUMGUNS) break;
+                if (!valid_weapon(nextprimary)) break;
                 cl->state.nextprimary = nextprimary;
                 break;
             }


### PR DESCRIPTION
- [X] Checked that the 5 primary weapons (Assault Rifle, Submachine Gun, Sniper Rifle, Shotgun, Carbine) can be selected by connecting
- [X] Checked that the 5 primary weapons (Assault Rifle, Submachine Gun, Sniper Rifle, Shotgun, Carbine) can be selected after connecting via the weapon change menu
- [X] Checked that connecting with the primary weapon ID 1000000 no longer crashes the server
- [X] Checked that changing to the primary weapon ID 1000000 after connecting no longer crashes the server
- [X] Checked that changing the primary weapon to CPISTOL does not work 